### PR TITLE
Use Python comment syntax in p) fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Multiline Python code can be loaded and executed using q scripts (but not from t
 ```bash
 $ cat test.q
 a:1                   / q code
-p)def add1(arg1):     / Python code
-    return arg1+1     / still Python code
+p)def add1(arg1):     # Python code
+    return arg1+1     # still Python code
 ```
 Then in a q session
 ```q


### PR DESCRIPTION
Recent versions of kdb+ don't strip comments, so q-style comments in p) fragments result in syntax error.