### PR TITLE
rlwrap should only be used when connected to a terminal

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ FROM base
 
 ARG VCS_REF=dev
 ARG BUILD_DATE=dev
+ARG L64_URL=https://cl.ly/2r1v1v3h0l41/download/l64.zip
 ARG L64_SHA256=28c26f796a7fa9267a3061598fe0e1e34208b4deb5932db42adc78f9d2a74481
 
 LABEL	org.label-schema.schema-version="1.0" \
@@ -62,11 +63,11 @@ ENV QHOME=/opt/kx/q
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/opt/conda/lib
 
 RUN mkdir -p $QHOME
-RUN curl -o $QHOME/l64.zip -L https://cl.ly/2r1v1v3h0l41/download/l64.zip \
-	&& [ "$L64_SHA256" = "$(sha256sum $QHOME/l64.zip | cut -b1-64)" ] \
-	&& unzip -d $QHOME $QHOME/l64.zip \
-        && rm $QHOME/l64.zip \
-        && apt-get -yy --option=Dpkg::options::=--force-unsafe-io purge unzip
+RUN curl -f -o /tmp/l64.zip -L $L64_URL \
+	&& [ "$L64_SHA256" = "$(sha256sum /tmp/l64.zip | cut -b1-64)" ] \
+	&& unzip -d $QHOME /tmp/l64.zip \
+	&& rm /tmp/l64.zip \
+	&& apt-get -yy --option=Dpkg::options::=--force-unsafe-io purge unzip
 COPY docker/q.wrapper /usr/local/bin/q
 COPY docker/kc.lic.py /opt/kx/
 

--- a/docker/q.wrapper
+++ b/docker/q.wrapper
@@ -2,4 +2,6 @@
 
 set -eu
 
-exec rlwrap $QHOME/l64/q "$@"
+[ -t 0 ] && RLWRAP=rlwrap || RLWRAP=
+
+exec $RLWRAP "$QHOME/l64/q" "$@"


### PR DESCRIPTION
We need to test that STDIO is connected to a TTY otherwise we may run q under rlwrap whilst under a superserver such as `(rl,x)?inetd` or even `systemd`.

So test for the presence of a TTY, and if not there skip using `rlwrap`.

Also so the docker image can be built, bump kdb+ to 3.6 (dated 20180614), though maybe you want to use the November release instead?