### PR TITLE
Change linux libpython .so file lookup

### DIFF
--- a/p.q
+++ b/p.q
@@ -3,7 +3,7 @@ if[not .P.loaded:-1h=type@[`.p@;`numpy;`];
  sc:{"'",x,"'.join([__import__('sysconfig').get_config_var(v)for v in",ssr[.j.j y;"\"";"'"],"])"};pr:{"print(",x,");"};
  c:"-c \"",pr["'.'.join([str(getattr(__import__('sys').version_info,x))for x in ['major','minor']])"],"\"2>",$[.z.o like"w*";"nul <nul";"/dev/null"];
  if[(.z.o like"w*")and `3.6>`$first@[system"python3 ",;c;{system"python ",c}];'"embedPy requires python 3.6 or higher on windows"];
- c:"-c \"",pr[$[.z.o like"w*";sc["/python";`BINDIR`VERSION],"+'.dll'";sc["/";`LIBDIR`INSTSONAME]]],pr[$[.z.o like"m*";sc["/";`PYTHONFRAMEWORKPREFIX`INSTSONAME];.z.o like"l*";sc["/";`LIBPL`LDLIBRARY];"''"]],pr["__import__('sys').prefix"],"\"2>",$[.z.o like"w*";"nul <nul";"/dev/null"];
+ c:"-c \"",pr[$[.z.o like"w*";sc["/python";`BINDIR`VERSION],"+'.dll'";sc["/";`LIBDIR`INSTSONAME]]],pr[$[.z.o like"m*";sc["/";`PYTHONFRAMEWORKPREFIX`INSTSONAME];.z.o like"l*";sc["/libpython";`LIBDIR`LDVERSION],"+'.so'";"''"]],pr["__import__('sys').prefix"],"\"2>",$[.z.o like"w*";"nul <nul";"/dev/null"];
  `L`M`H set'@[system"python3 ",;c;{system"python ",c}];if[count M;if[k~key k:`$":",M;L::M]];
  .p:(`:./p 2:(`init;2))[L;H]]
 loaded:.P.loaded


### PR DESCRIPTION
In certain conda versions of python, the sysconfig info for LDLIBRARY
now point to static .a file libraries instead of .so.

It appears libpython can be found using LIBDIR and LDVERSION with
a libpython prefix and .so suffix added

Here is a conda environment conda.yml file that can be used to 
experience the issue.

```
name: derek
channels:
  - defaults
  - conda-forge
  - r
dependencies:
  - python=3.6
  - jupyterlab
  - numpy
  - pandas
  - matplotlib
  - flask
  - psycopg2
  - tensorflow
  - r-essentials
  - pip:
    - influxdb
```

Before the change in this PR, loading p.q fails with 'libpython.

After the change, embedPy works.

Using the following versions of software:

```
KDB+ 3.6 2018.12.06 Copyright (C) 1993-2018 Kx Systems
l64/ 8(16)core 15763MB derek gunslinger 127.0.0.1 EXPIRE 2019.12.14 derekwisong@gmail.com KOD #4162903
```

```
Python 3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34) 
[GCC 7.3.0] on linux
```