### PR TITLE
Minor fix to CI tests

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -14,7 +14,7 @@ set PATH=C:\Miniconda3-x64;C:\Miniconda3-x64\Scripts;%PATH%
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
 :: install conda build requirements (use version < 3.12 to avoid warning about verify in output file)
 conda install -y "conda-build<3.12"                                       || goto :error
-conda install -y anaconda-client conda=4.5.4                              || goto :error
+conda install -y anaconda-client conda=4.7.12                             || goto :error
 :: set up kdb+ if available
 if defined QLIC_KC ( echo|set /P=%QLIC_KC% > kc.lic.enc & certutil -decode kc.lic.enc kc.lic & set QLIC=%CD%)
 if "%APPVEYOR_REPO_TAG%"=="true" ( set EMBEDPY_VERSION=%APPVEYOR_REPO_TAG_NAME% )

--- a/build/build.bat
+++ b/build/build.bat
@@ -14,7 +14,7 @@ set PATH=C:\Miniconda3-x64;C:\Miniconda3-x64\Scripts;%PATH%
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
 :: install conda build requirements (use version < 3.12 to avoid warning about verify in output file)
 conda install -y "conda-build<3.12"                                       || goto :error
-conda install -y anaconda-client conda=4.5.1                              || goto :error
+conda install -y anaconda-client conda=4.7.1                              || goto :error
 :: set up kdb+ if available
 if defined QLIC_KC ( echo|set /P=%QLIC_KC% > kc.lic.enc & certutil -decode kc.lic.enc kc.lic & set QLIC=%CD%)
 if "%APPVEYOR_REPO_TAG%"=="true" ( set EMBEDPY_VERSION=%APPVEYOR_REPO_TAG_NAME% )

--- a/build/build.bat
+++ b/build/build.bat
@@ -14,7 +14,7 @@ set PATH=C:\Miniconda3-x64;C:\Miniconda3-x64\Scripts;%PATH%
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
 :: install conda build requirements (use version < 3.12 to avoid warning about verify in output file)
 conda install -y "conda-build<3.12"                                       || goto :error
-conda install -y anaconda-client conda=4.7.1                              || goto :error
+conda install -y anaconda-client conda=4.5.4                              || goto :error
 :: set up kdb+ if available
 if defined QLIC_KC ( echo|set /P=%QLIC_KC% > kc.lic.enc & certutil -decode kc.lic.enc kc.lic & set QLIC=%CD%)
 if "%APPVEYOR_REPO_TAG%"=="true" ( set EMBEDPY_VERSION=%APPVEYOR_REPO_TAG_NAME% )

--- a/makefile
+++ b/makefile
@@ -46,3 +46,4 @@ install:
 	install $(TGT) $(Q)
 clean:
 	rm -f p.so
+	rm -f $(QARCH)/p.so

--- a/tests/tensorflow.t
+++ b/tests/tensorflow.t
@@ -3,7 +3,7 @@
 setenv[`TF_CPP_MIN_LOG_LEVEL]1#"2"
 p)import tensorflow as tf
 p)def fit(x_data,y_data): #adapted from https://www.tensorflow.org/get_started
- W = tf.Variable(tf.random_uniform([1], -1.0, 1.0))
+ W = tf.Variable(tf.random.uniform([1], -1.0, 1.0))
  b = tf.Variable(tf.zeros([1]))
  y = W * x_data + b
  loss = tf.reduce_mean(tf.square(y - y_data))


### PR DESCRIPTION
Fixes required based on default versions of python packages being used
* conda version incompatible with 3.7
* `random_uniform` deprecated thus move to `random.uniform`