### PR TITLE
 Update Makefile for filtering on arm, README includes for potential symlink on arm 32-bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,21 +87,25 @@ If the tests all pass, no message is displayed.
 
 1.  Clone this repository from GitHub.
 
-1.  To run embedPy without Internet access, download the kdb+ [C API header file](https://raw.githubusercontent.com/KxSystems/kdb/master/c/c/k.h) and place it in the build directory.
+2.  To run embedPy without Internet access, download the kdb+ [C API header file](https://raw.githubusercontent.com/KxSystems/kdb/master/c/c/k.h) and place it in the build directory.
 
-1.  Build the interface and run the [tests](#test-script).
+3.  Build the interface and run the [tests](#test-script).
 
     ```bash
     $ make p.so && q test.q
     ```
 
-1.  Install: put `p.q` and `p.k` in `$QHOME` and `p.so` in `$QHOME/{l64,l32,m64}`.
+4.  Install: put `p.q` and `p.k` in `$QHOME` and `p.so` in `$QHOME/{l64,l32,m64}`.
 
 
-**Note**
+**Notes**
 
-For ease of install on 32-bit Arm and linux it is suggested that a new user should use a miniconda version of python specific to the architecture being used, `for example rpi for raspberry pi`. This is not an explicit requirement but makes install of embedPy and python packages more seamless.
+* For ease of install on 32-bit Arm and linux it is suggested that a new user should use a miniconda version of python specific to the architecture being used, `for example rpi for raspberry pi`. This is not an explicit requirement but makes install of embedPy and python packages more seamless.
 
+* Installation of embedPy on a 32-bit arm system may also necessitate the addition of the `libpython` shared object to an access point available to embedPy. For example if Python is located within `/usr/lib/arm-linux-gnueabihf/` which is not on accessible then creating a symlink to `/usr/lib` will allow the shared object to be accessed.
+	```bash
+	ln -s /usr/lib /usr/lib/arm-linux-gnueabihf
+	``` 
 
 ### Install with Conda
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If the tests all pass, no message is displayed.
 
 * For ease of install on 32-bit Arm and linux it is suggested that a new user should use a miniconda version of python specific to the architecture being used, `for example rpi for raspberry pi`. This is not an explicit requirement but makes install of embedPy and python packages more seamless.
 
-* Installation of embedPy on a 32-bit arm system may also necessitate the addition of the `libpython` shared object to an access point available to embedPy. For example if Python is located within `/usr/lib/arm-linux-gnueabihf/` which is not on accessible then creating a symlink to `/usr/lib` will allow the shared object to be accessed.
+* Installation of embedPy on a 32-bit arm system may also necessitate the addition of the `libpython` shared object to an access point available to embedPy. For example if Python is located within `/usr/lib/arm-linux-gnueabihf/` which may not be accessible then creating a symlink to `/usr/lib` will allow the shared object to be located.
 	```bash
 	ln -s /usr/lib /usr/lib/arm-linux-gnueabihf
 	``` 

--- a/makefile
+++ b/makefile
@@ -8,10 +8,10 @@ ifeq ($(UNAME_S),Linux)
   OSFLAG  = l
   LDFLAGS = -fPIC -shared
   ifeq ($(UNAME_M),armv7l)
-    CFLAGS  += $(filter-out -Wwrite-strings,$(CFLAGS))
+    CFLAGS  := $(filter-out -Wwrite-strings,$(CFLAGS))
   else
   ifeq ($(UNAME_M),armv6l)
-    CFLAGS  += $(filter-out -Wwrite-strings,$(CFLAGS))
+    CFLAGS  := $(filter-out -Wwrite-strings,$(CFLAGS))
   endif
   endif
 else ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
* Implementation of filter-out for arm builds of embedPy on certain compilers resulted in the error 
  ```
  makefile:11: *** Recursive variable 'CFLAGS' references itself (eventually).  Stop.
  ```
  This is fixed by moving from assignment update `+=` to `:=` which is an immediate update rather than a delayed expansion (hence eventual)
* README.md now includes information on the potential need to symlink to the location of your python install on arm.